### PR TITLE
fix capture error

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -95,7 +95,6 @@ async function rePub(
 
     await tab.complete(outputStyle === "download" ? "done" : "sent");
   } catch (ex) {
-    console.trace(ex);
     const msg = ex instanceof Error ? ex.toString() : "unknown error";
     await Promise.all([
       chrome.notifications.create({

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -4,11 +4,17 @@ export async function pageCapture(
   { retries = 3 }: { retries?: number } = {},
 ): Promise<ArrayBuffer> {
   for (; retries; --retries) {
-    const blob = await chrome.pageCapture.saveAsMHTML({ tabId });
-    if (blob) {
-      return await blob.arrayBuffer();
-    } else {
-      console.warn(chrome.runtime.lastError);
+    try {
+      // NOTE this occasionally returns null, or throws an error for not being
+      // available, both of these are transient, so we just retry
+      const blob = await chrome.pageCapture.saveAsMHTML({ tabId });
+      if (blob) {
+        return await blob.arrayBuffer();
+      } else {
+        console.warn(chrome.runtime.lastError);
+      }
+    } catch (ex) {
+      console.warn(ex);
     }
   }
   throw new Error("couldn't fetch page");


### PR DESCRIPTION
Occasionally, often after starting chrome, this extension would error instead of capturing the page. This was difficult to debug because it was sporadic, and chrome was refusing to give stack traces. However, after some digging, I believe I've found the source, so this should no longer happen after this is pushed.

fixes #20 